### PR TITLE
Fix header image paths for routes

### DIFF
--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -21,13 +21,13 @@ export function Header() {
         <HeaderBlock>
           <LogoWrapper>
             <a href="">
-              <img src="images/logo.png" alt="logo" />
+              <img src="/images/logo.png" alt="logo" />
             </a>
           </LogoWrapper>
 
           <DarkLogo>
             <a href="">
-              <img src="images/logo_dark.png" alt="logo" />
+              <img src="/images/logo_dark.png" alt="logo" />
             </a>
           </DarkLogo>
 


### PR DESCRIPTION
## Summary
- fix header logos to use absolute image paths

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_683ff7cb9014832b8cb9a58074571fbb